### PR TITLE
Skip deployment when the build context is not production

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ path = "/api/" # The prefix path to access your deployed packages.
 
 In this section, you will learn how to structure your repository and `netlify.toml` for this plugin to deploy your functions on Nimbella Cloud.
 
+**Note:** Deployment of packages/functions to Nimbella is skipped when the build context is not production. We're working on an enhancement that will allow you to deploy preview builds to staging namespace on Nimbella.
+
 #### Use Nimbella Projects with Netlify Sites
 
 The Nimbella add-on for Netlify allows you to use [Nimbella projects](https://nimbella.io/downloads/nim/nim.html#overview-of-nimbella-projects-actions-and-deployment) to automate packaging and deployment. We suggest reading the documentation about [Nimbella projects](https://nimbella.io/downloads/nim/nim.html#overview-of-nimbella-projects-actions-and-deployment) at some point. We provide a quick introduction here.

--- a/index.js
+++ b/index.js
@@ -124,18 +124,23 @@ module.exports = {
     try {
       const {stdout: namespace} = await utils.run.command(`nim auth current`);
 
-      if (isProject) {
-        await deployProject(utils.run);
-      }
+      if (process.env.CONTEXT === 'production') {
+        if (isProject) {
+          await deployProject(utils.run);
+        }
 
-      if (isActions) {
-        await deployActions({
-          run: utils.run,
-          functionsDir: functionsBuildDir,
-          secretsPath: join(process.cwd(), 'env.json'),
-          timeout: options.timeout, // Default is 6 seconds
-          memory: options.memory // Default is 256MB (max for free tier)
-        });
+        if (isActions) {
+          await deployActions({
+            run: utils.run,
+            functionsDir: functionsBuildDir,
+            timeout: options.timeout, // Default is 6 seconds
+            memory: options.memory // Default is 256MB (max for free tier)
+          });
+        }
+      } else {
+        console.log(
+          `Skipping the deployment to Nimbella as the context (${process.env.CONTEXT}) is not production.`
+        );
       }
 
       const redirectRules = [];


### PR DESCRIPTION
Only the deployment is skipped. The plugin will run as usual generating _redirect rules if any. 

See issue #13.