### PR TITLE
Include only required files in npm bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "pre-commit": "yarn test"
     }
   },
+  "files": [
+    "manifest.yml",
+    "index.js"
+  ],
   "devDependencies": {
     "husky": "^4.3.0",
     "xo": "^0.33.0"


### PR DESCRIPTION
npm will include the readme, package.json, and license additionally. 