### PR TITLE
Deploy Netlify functions as Nimbella actions.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -18,8 +18,6 @@ inputs:
 
   - name: timeout
     description: Timeout LIMIT in milliseconds to apply to all Netlify functions running on Nimbella.
-    default: 6000
 
   - name: memory
     description: Memory LIMIT in MB to apply to all Netlify functions running on Nimbella.
-    default: 256

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,18 @@ inputs:
     description: Deploy entire project include web frontend. Proxy domain to Nimbella.
     default: false
 
-  - name: env
+  - name: envs
     description: Environment variables to forward from Netlify CI to Nimbella Projects.
     default: []
+
+  ## These are deprecated: migrate to using Nimbella project.yml instead which permit per-API level control.
+  - name: functions
+    description: The source directory containing Netlify functions to deploy to Nimbella.
+
+  - name: timeout
+    description: Timeout LIMIT in milliseconds to apply to all Netlify functions running on Nimbella.
+    default: 6000
+
+  - name: memory
+    description: Memory LIMIT in MB to apply to all Netlify functions running on Nimbella.
+    default: 256

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/nimbella/netlify-plugin-nimbella#readme",
   "dependencies": {
-    "@iarna/toml": "^2.2.5",
     "cpx": "^1.5.0",
     "make-dir": "^3.1.0",
     "netlify-lambda": "satyarohith/netlify-lambda#88eac6a37bfb0920897c86ecda8682944a2bf5be",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
   "homepage": "https://github.com/nimbella/netlify-plugin-nimbella#readme",
   "dependencies": {
     "make-dir": "^3.1.0",
-    "nimbella-cli": "https://apigcp.nimbella.io/downloads/nim/nimbella-cli.tgz"
+    "nimbella-cli": "https://apigcp.nimbella.io/downloads/nim/nimbella-cli.tgz",
+    "@iarna/toml": "^2.2.5",
+    "cpx": "^1.5.0",
+    "netlify-lambda": "satyarohith/netlify-lambda#88eac6a37bfb0920897c86ecda8682944a2bf5be",
+    "netlify-redirect-parser": "^2.5.0"
   },
   "xo": {
     "space": true,

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://github.com/nimbella/netlify-plugin-nimbella#readme",
   "dependencies": {
-    "make-dir": "^3.1.0",
-    "nimbella-cli": "https://apigcp.nimbella.io/downloads/nim/nimbella-cli.tgz",
     "@iarna/toml": "^2.2.5",
     "cpx": "^1.5.0",
+    "make-dir": "^3.1.0",
     "netlify-lambda": "satyarohith/netlify-lambda#88eac6a37bfb0920897c86ecda8682944a2bf5be",
-    "netlify-redirect-parser": "^2.5.0"
+    "netlify-redirect-parser": "^2.5.0",
+    "nimbella-cli": "https://apigcp.nimbella.io/downloads/nim/nimbella-cli.tgz"
   },
   "xo": {
     "space": true,

--- a/src/index.js
+++ b/src/index.js
@@ -210,6 +210,9 @@ module.exports = {
         fnRewrites.push(...redirectRules)
         await writeFile(redirectsFile, fnRewrites.join('\n') + '\n')
         await appendFile(redirectsFile, content)
+
+        const rf = await readFile(redirectsFile)
+        console.log(`Redirects:\n${rf}`)
       }
     }
   }

--- a/src/nfn.js
+++ b/src/nfn.js
@@ -127,7 +127,7 @@ async function buildAndDeployNetlifyFunctions({utils, inputs}) {
   const functionsBuildDir = `functions-build-${Date.now()}`
 
   try {
-    const stats = await build.run(functionsBuildDir)
+    const stats = await build.run(functionsBuildDir, inputs.functions)
     console.log(stats.toString(stats.compilation.options.stats))
     // Copy any remaining files that do not end with '.js'.
     // Arguably we should not do this, if the functions are Netlify

--- a/src/nfn.js
+++ b/src/nfn.js
@@ -18,11 +18,15 @@ async function deployActions({run, functionsDir, timeout, memory, envsFile}) {
   await Promise.all(
     files.map(async (file) => {
       const [actionName, extension] = file.split('.') // This assume name.ext format
-      const command = [
-        `nim action update ${actionName} ${join(functionsDir, file)}`,
-        `--timeout=${Number(timeout)} --memory=${Number(memory)} `,
-        `--web=raw`
-      ]
+      const command = [`nim action update ${actionName} ${join(functionsDir, file)} --web=raw`]
+
+      if (timeout) {
+        command.push(`--timeout=${Number(timeout)}`)
+      }
+
+      if (memory) {
+        command.push(`--memory=${Number(memory)}`)
+      }
 
       if (extension === 'js') {
         // Run node functions with lambda compatibility
@@ -31,14 +35,15 @@ async function deployActions({run, functionsDir, timeout, memory, envsFile}) {
         const chalk = require('chalk')
 
         // Else let the cli infer the kind based on the file extension
-        console.warn(`
-           ${chalk.yellow(
-             file + ': Lambda compatibility is not available for this function.'
-           )}
-           The main handler must be called 'main', must accept a JSON object as input, and return JSON object as output.
-           The function will run as Apache OpenWhisk action on the Nimbella Cloud.
-           See https://github.com/apache/openwhisk/blob/master/docs/actions.md#languages-and-runtimes
-           for examples of serverless function signatures that are comptatible.`)
+        console.warn(
+          chalk.yellow(
+            file + ': Lambda compatibility is not available for this function.'
+          ),
+          `The main handler must be called 'main', must accept a JSON object as input, and return JSON object as output.`,
+          'The function will run as Apache OpenWhisk action on the Nimbella Cloud.',
+          'See https://github.com/apache/openwhisk/blob/master/docs/actions.md#languages-and-runtimes',
+          'for examples of serverless function signatures that are comptatible.'
+        )
       }
 
       if (envsFile) {
@@ -51,7 +56,7 @@ async function deployActions({run, functionsDir, timeout, memory, envsFile}) {
       })
 
       const message = exitCode === 0 && !failed ? 'done.' : String(stderr)
-      console.log(`Deployed ${file}: ${message}`)
+      console.log(`Deployment status ${file}: ${message}`)
     })
   )
 }

--- a/src/nfn.js
+++ b/src/nfn.js
@@ -1,0 +1,108 @@
+const {readdir, writeFile} = require('fs').promises
+const {join} = require('path')
+const {tmpdir} = require('os')
+
+/**
+ * Deploys actions under a directory. Currently limited to lambda functions.
+ *
+ * @param {function} run - function provided under utils by Netlify to build event functions.
+ * @param {string} functionsDir - Path to the functions/actions directory.
+ * @param {string} timeout - Max allowed duration for each function activation.
+ * @param {string} memory - Max memory allowed for each function activation.
+ * @param {string} envsFile - Path to environment file (optional).
+ */
+async function deployActions({run, functionsDir, timeout, memory, envsFile}) {
+  const files = await readdir(functionsDir)
+
+  await Promise.all(
+    files.map(async (file) => {
+      const [actionName, extension] = file.split('.') // This assume name.ext format
+      const command = [
+        `nim action update ${actionName} ${join(functionsDir, file)}`,
+        `--timeout=${Number(timeout)} --memory=${Number(memory)} `,
+        `--web=raw`
+      ]
+
+      if (extension === 'js') {
+        // Run node functions with lambda compatibility
+        command.push('--kind nodejs-lambda:10 --main handler')
+      } else {
+        const chalk = require('chalk')
+
+        // Else let the cli infer the kind based on the file extension
+        console.warn(`
+           ${chalk.yellow(
+             file + ': Lambda compatibility is not available for this function.'
+           )}
+           The main handler must be called 'main', must accept a JSON object as input, and return JSON object as output.
+           The function will run as Apache OpenWhisk action on the Nimbella Cloud.
+           See https://github.com/apache/openwhisk/blob/master/docs/actions.md#languages-and-runtimes
+           for examples of serverless function signatures that are comptatible.`)
+      }
+
+      if (envsFile) {
+        command.push(`--env-file=${envsFile}`)
+      }
+
+      const {stderr, exitCode, failed} = await run.command(command.join(' '), {
+        reject: false,
+        stdout: 'ignore'
+      })
+
+      const message = exitCode === 0 && !failed ? 'done.' : String(stderr)
+      console.log(`Deployed ${file}: ${message}`)
+    })
+  )
+}
+
+async function constructEnvFileAsJson(inputs) {
+  if (inputs.envs && inputs.envs.length > 0) {
+    const toExport = {}
+    const filename = join(tmpdir(), 'env.json')
+
+    inputs.envs.forEach((env) => {
+      toExport[env] = process.env[env]
+    })
+
+    await writeFile(filename, JSON.stringify(toExport))
+    return filename
+  }
+}
+
+async function buildAndDeployNetlifyFunctions({utils, inputs}) {
+  const cpx = require('cpx')
+  const build = require('netlify-lambda/lib/build')
+  const functionsBuildDir = `functions-build-${Date.now()}`
+
+  try {
+    const stats = await build.run(functionsBuildDir)
+    console.log(stats.toString(stats.compilation.options.stats))
+    // Copy any remaining files that do not end with '.js'.
+    // Arguably we should not do this, if the functions are Netlify
+    // functions (Lambda) they will not run as is in the OpenWhisk
+    // runtime used by Nimbella. Will issue warning during deploy.
+    cpx.copySync(inputs.functions + '/**/*.!(js)', functionsBuildDir)
+  } catch (error) {
+    utils.build.failBuild('Failed to build the functions', {error})
+    return
+  }
+
+  try {
+    const envsFile = await constructEnvFileAsJson(inputs)
+    await deployActions({
+      run: utils.run,
+      envsFile,
+      functionsDir: functionsBuildDir,
+      timeout: inputs.timeout, // Default setting applies
+      memory: inputs.memory // Default setting applies
+    })
+  } catch (error) {
+    utils.build.failBuild('Failed to deploy the functions', {error})
+  }
+}
+
+module.exports = {
+  deployActions,
+  constructEnvFileAsJson,
+  buildAndDeployNetlifyFunctions
+}

--- a/test/nfn.test.js
+++ b/test/nfn.test.js
@@ -190,12 +190,44 @@ describe('supporting functions', () => {
     mockFs.restore()
 
     expect(utils.run.command.mock.calls[0][0]).toEqual(
-      'nim action update jshello somePath/jshello.js --timeout=120 --memory=256  --web=raw --kind nodejs-lambda:10 --main handler --env-file=env.json'
+      'nim action update jshello somePath/jshello.js --web=raw --timeout=120 --memory=256 --kind nodejs-lambda:10 --main handler --env-file=env.json'
     )
     expect(utils.run.command.mock.calls[1][0]).toEqual(
-      'nim action update pyhello somePath/pyhello.py --timeout=120 --memory=256  --web=raw --env-file=env.json'
+      'nim action update pyhello somePath/pyhello.py --web=raw --timeout=120 --memory=256 --env-file=env.json'
     )
-    expect(console.warn.mock.calls[0][0].split('\n')[1].trim()).toEqual(
+    expect(console.warn.mock.calls[0][0]).toEqual(
+      'pyhello.py: Lambda compatibility is not available for this function.'
+    )
+  })
+
+  test('Should deploy actions with default limits', async () => {
+    mockFs({
+      somePath: {'jshello.js': '', 'pyhello.py': ''},
+      'env.json': '{}',
+      // eslint-disable-next-line camelcase
+      node_modules
+    })
+
+    utils.run.command.mockResolvedValue({
+      stderr: '',
+      exitCode: 0,
+      failed: false
+    })
+
+    await deployActions({
+      run: utils.run,
+      envsFile: 'env.json',
+      functionsDir: 'somePath'
+    })
+    mockFs.restore()
+
+    expect(utils.run.command.mock.calls[0][0]).toEqual(
+      'nim action update jshello somePath/jshello.js --web=raw --kind nodejs-lambda:10 --main handler --env-file=env.json'
+    )
+    expect(utils.run.command.mock.calls[1][0]).toEqual(
+      'nim action update pyhello somePath/pyhello.py --web=raw --env-file=env.json'
+    )
+    expect(console.warn.mock.calls[0][0]).toEqual(
       'pyhello.py: Lambda compatibility is not available for this function.'
     )
   })

--- a/test/nfn.test.js
+++ b/test/nfn.test.js
@@ -1,0 +1,135 @@
+const fs = require('fs')
+const mockFs = require('mock-fs')
+const path = require('path')
+const build = require('netlify-lambda/lib/build')
+const plugin = require('../src')
+const {constructEnvFileAsJson, deployActions} = require('../src/nfn')
+
+const utils = {
+  cache: {
+    restore: jest.fn(),
+    save: jest.fn(),
+    has: jest.fn()
+  },
+  run: {
+    command: jest.fn()
+  },
+  build: {
+    failBuild: jest.fn()
+  }
+}
+
+jest.mock('netlify-lambda/lib/build')
+jest.mock('chalk', () => ({yellow: (_) => _}))
+
+console.log = jest.fn()
+console.warn = jest.fn()
+
+afterEach(() => {
+  delete require.cache[require.resolve('../src')]
+  utils.build.failBuild.mockReset()
+  utils.run.command.mockReset()
+  utils.cache.has.mockReset()
+  utils.cache.restore.mockReset()
+  utils.cache.save.mockReset()
+  build.run.mockReset()
+  console.log.mockReset()
+  console.warn.mockReset()
+})
+
+describe('preBuild()', () => {
+  test('Should fail build if a Nimbella project and functions directory are both present', async () => {
+    process.env.NIMBELLA_LOGIN_TOKEN = 'somevalue'
+
+    const pluginInputs = {
+      utils,
+      inputs: {functions: 'somePath'}
+    }
+
+    mockFs({
+      packages: {},
+      somePath: {},
+      // eslint-disable-next-line camelcase
+      node_modules: mockFs.load(path.resolve(__dirname, '../node_modules'))
+    })
+
+    await plugin.onPreBuild(pluginInputs)
+    mockFs.restore()
+
+    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
+      'Detected both a Nimbella project and a functions directory. Use one or the other.'
+    )
+  })
+})
+
+describe('onBuild', () => {
+  test('Should build functions if functions input is set in config ', async () => {
+    process.env.NIMBELLA_LOGIN_TOKEN = 'somevalue'
+    process.env.CONTEXT = 'production'
+
+    const pluginInputs = {
+      utils,
+      inputs: {functions: 'somePath'}
+    }
+
+    mockFs({
+      somePath: {},
+      // eslint-disable-next-line camelcase
+      node_modules: mockFs.load(path.resolve(__dirname, '../node_modules'))
+    })
+
+    await plugin.onPreBuild(pluginInputs)
+    await plugin.onBuild(pluginInputs)
+    mockFs.restore()
+
+    expect(build.run.mock.calls[0][0]).toMatch(/functions-build-\d+/)
+  })
+
+  test('Should export env.json file', async () => {
+    process.env.ENV1 = 'someenv1'
+    process.env.ENV2 = 'someenv2'
+
+    mockFs({})
+    const envFile = await constructEnvFileAsJson({
+      envs: ['ENV1', 'ENV2']
+    })
+    const envsJson = String(fs.readFileSync(envFile))
+    mockFs.restore()
+
+    expect(JSON.parse(envsJson)).toEqual({ENV1: 'someenv1', ENV2: 'someenv2'})
+  })
+
+  test('Should deploy actions', async () => {
+    mockFs({
+      somePath: {'jshello.js': '', 'pyhello.py': ''},
+      'env.json': '{}',
+      // eslint-disable-next-line camelcase
+      node_modules: mockFs.load(path.resolve(__dirname, '../node_modules'))
+    })
+
+    utils.run.command.mockResolvedValue({
+      stderr: '',
+      exitCode: 0,
+      failed: false
+    })
+
+    await deployActions({
+      run: utils.run,
+      envsFile: 'env.json',
+      functionsDir: 'somePath',
+      timeout: '120',
+      memory: '256'
+    })
+    mockFs.restore()
+
+    expect(utils.run.command.mock.calls[0][0]).toEqual(
+      'nim action update jshello somePath/jshello.js --timeout=120 --memory=256  --web=raw --kind nodejs-lambda:10 --main handler --env-file=env.json'
+    )
+    expect(utils.run.command.mock.calls[1][0]).toEqual(
+      'nim action update pyhello somePath/pyhello.py --timeout=120 --memory=256  --web=raw --env-file=env.json'
+    )
+    expect(console.warn.mock.calls[0][0].split('\n')[1].trim()).toEqual(
+      'pyhello.py: Lambda compatibility is not available for this function.'
+    )
+  })
+})


### PR DESCRIPTION
This PR restores plugin input (functions, timeout, memory) dropped in v2.0.0 but issues deprecation warnings when used. Deploying Netlify functions as Nimbella actions is consequently re-enabled, with robustness improvements and better error handling.